### PR TITLE
CHANGE: to_path now uses a reference rather than a DevTreeIndexNode

### DIFF
--- a/src/dt.rs
+++ b/src/dt.rs
@@ -89,19 +89,17 @@ pub fn read_two_items(prop: DevTreeIndexProp, acells: u32, scells: u32) -> Vec<R
     return result;
 }
 
-pub fn to_path(node: DevTreeIndexNode) -> String {
-    let mut path: String = String::from("");
-    let mut current = node;
-    path += current.name().unwrap();
-    loop {
-        let parent = current.parent();
-        match parent {
-            None =>  break,
-            Some(ref n) => path = String::from((*n).name().unwrap()) + "/" + &path
-        }
-        current = parent.unwrap();
+pub fn to_path<'a, 'i, 'dt>(node: &DevTreeIndexNode) -> String {
+
+    let pp = node.parent();
+    let parent  = pp.as_ref();
+    if let Some(p) = parent {
+        let prefix = to_path(p);
+        return prefix + "/" + &node.name().unwrap();
+    } 
+    else {
+        return String::from("");
     }
-    return path;
 }
 
 /* the items is assumed to be two element: <name to search> and <name to search@>
@@ -112,7 +110,7 @@ fn matches_name(node: DevTreeIndexNode, items: &Vec<&str>) -> bool {
 }
 
 fn matches_path(node: DevTreeIndexNode, items: &Vec<&str>) -> bool {
-    let binding = to_path(node);
+    let binding = to_path(&node);
     let path = binding.as_str();
     return path.eq(items[0]) || path.starts_with(items[1]);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,10 @@ fn main() {
         Some(ref c) => c
     };
     
-    /*
-    let path = dt::to_path(stdout);
+
+    let path = dt::to_path(&stdout);
     println!("stdout-path={}", path);
-    */
+
 
     let compatible_prop = devt.get_prop_by_name(&stdout, "compatible").unwrap();
     let mut compatible_strings = compatible_prop.iter_str();


### PR DESCRIPTION
In the journey to understand Rust ownership and lifetimes I migrated to_path to use references. Which led to use recursion rather than loop to keep lifetimes under control.

More generally, I would love to find a way to avoid creation of temporary objects (node.parent() creates a new one rather than giving a reference to it. As most of the time values won't change it seems a better approach but unsure at this stage of Rust learning